### PR TITLE
[12.0][FIX] control on vat format

### DIFF
--- a/l10n_be_vat_reports/wizard/partner_vat_list_client.py
+++ b/l10n_be_vat_reports/wizard/partner_vat_list_client.py
@@ -21,17 +21,17 @@ class VATListingClients(models.TransientModel):
     @api.constrains("vat")
     def _check_vat_number(self):
         """
-        Belgium VAT numbers must respect this pattern: 0[1-9]{1}[0-9]{8}
+        Belgium VAT numbers must respect this pattern: [0-1][1-9]{1}[0-9]{8}
         todo current code assumes vat numbers start with a two-letter
           country code
         """
-        be_vat_pattern = re.compile(r"^BE0[1-9]{1}[0-9]{8}$")
+        be_vat_pattern = re.compile(r"^BE[0-1][1-9]{1}[0-9]{8}$")
         for client in self:
             if not be_vat_pattern.match(client.vat):
                 raise ValidationError(
                     _(
                         "Belgian Intervat platform only accepts VAT numbers "
-                        "matching this pattern: 0[1-9]{1}[0-9]{8} (number "
+                        "matching this pattern: [0-1][1-9]{1}[0-9]{8} (number "
                         "part). Check vat number %s for client %s"
                     )
                     % (client.vat, client.name)


### PR DESCRIPTION
Belgian VAT number now can start with a 1 rather than a 0 (see https://www.easytax.co/fr/tax-mag/info/belgique-changement-de-format-pour-les-numeros-de-tva-belges/)